### PR TITLE
new functions for recodes should accept aliases, urls or objects as reference to the original variable

### DIFF
--- a/docs/manipulation.md
+++ b/docs/manipulation.md
@@ -35,7 +35,7 @@ At the moment *filter expressions* can be composed using the following logical e
 | operator | meaning               |
 |:--------:|-----------------------|
 | ==       | eqal                  |
-| !=       | unequal                |
+| !=       | unequal               |
 | >        | greater than          |
 | >=       | greater or eqal       |
 | <        | less than             |
@@ -86,7 +86,7 @@ category_recode = {
 
 new_var = combine_categories(
     dataset=my_dataset, 
-    from_alias='brandrating', 
+    variable='brandrating', 
     category_map=category_recode, 
     name='Brandrating 2', 
     alias='brandrating2', 
@@ -108,7 +108,7 @@ response_mappings = {
 
 new_var = combine_responses(
     dataset=my_dataset, 
-    from_alias='from_alias', 
+    variable='original_variable_alias', 
     response_map=response_mappings,
     name='Brandrating 3', 
     alias='brandrating3', 

--- a/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
+++ b/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
@@ -432,7 +432,7 @@ def main():
         ]
 
         new_var = create_categorical(
-            ds=dataset,
+            dataset=dataset,
             categories=categories,
             rules=rules,
             name='Operating System Users',

--- a/pycrunch/tests/test_recodes.py
+++ b/pycrunch/tests/test_recodes.py
@@ -23,6 +23,39 @@ RESPONSE_MAP = {
     'newsubvar': ['sub1', 'sub2']
 }
 
+RECODES_PAYLOAD = {
+    "element": "shoji:entity",
+    "body": {
+        "name": "name",
+        "description": "",
+        "alias": "alias",
+        "expr": {
+            "function": "combine_categories",
+            "args": [
+                {
+                    "variable": 'http://test.crunch.io/api/datasets/123/variables/0001/'
+                },
+                {
+                    "value": [
+                        {
+                            "name": "China",
+                            "id": 1,
+                            "missing": False,
+                            "combined_ids": [2, 3]
+                        },
+                        {
+                            "name": "Other",
+                            "id": 2,
+                            "missing": False,
+                            "combined_ids": [1]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+
 
 class TestRecodes(TestCase):
 
@@ -67,37 +100,6 @@ class TestRecodes(TestCase):
         }
         combine_categories(ds, 'test', CATEGORY_MAP, 'name', 'alias')
         call = ds.variables.create.call_args_list[0][0][0]
-        recodes_payload = {
-            "element": "shoji:entity",
-            "body": {
-                "name": "name",
-                "description": "",
-                "alias": "alias",
-                "expr": {
-                    "function": "combine_categories",
-                    "args": [
-                        {
-                            "variable": 'http://test.crunch.io/api/datasets/123/variables/0001/'
-                        },
-                        {
-                            "value": [
-                                {
-                                    "name": "China",
-                                    "id": 1,
-                                    "missing": False,
-                                    "combined_ids": [2, 3]
-                                },
-                                {
-                                    "name": "Other",
-                                    "id": 2,
-                                    "missing": False,
-                                    "combined_ids": [1]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
         }
         assert call == recodes_payload
 

--- a/pycrunch/tests/test_recodes.py
+++ b/pycrunch/tests/test_recodes.py
@@ -1,3 +1,4 @@
+import json
 from unittest import TestCase
 from unittest import mock
 
@@ -166,21 +167,32 @@ class TestRecodes(TestCase):
         subvar1_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00001/'
         subvar2_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00002/'
         ds.entity.self = 'http://test.crunch.io/api/datasets/123/'
-        entity_mock = mock.MagicMock()
-        entity_mock.entity.self = var_url
+
         # mock subvariables
         subvar_mock = mock.MagicMock()
         subvar_mock.entity.self = subvar1_url
         subvar2_mock = mock.MagicMock()
         subvar2_mock.entity.self = subvar2_url
-        # add dictionaries return to by function
+
+        # mock parent variable
+        entity_mock = mock.MagicMock()
+        entity_mock.entity.self = var_url
+
+        # add dictionaries return to by functions
         entity_mock.entity.subvariables.by.return_value = {
             'sub1': subvar_mock,
             'sub2': subvar2_mock
         }
+
         ds.variables.by.return_value = {
             'test': entity_mock
         }
+
+        # mock response from ds.session.get(variable_url)
+        var_response = mock.MagicMock()
+        var_response.payload = entity_mock.entity
+        ds.session.get.return_value = var_response
+
         # make the actual response call
         combine_responses(ds, 'test', RESPONSE_MAP, 'name', 'alias')
         call = ds.variables.create.call_args_list[0][0][0]

--- a/pycrunch/tests/test_recodes.py
+++ b/pycrunch/tests/test_recodes.py
@@ -161,7 +161,7 @@ class TestRecodes(TestCase):
 
         assert call == RECODES_PAYLOAD
 
-    def test_combine_responses(self):
+    def test_combine_responses_by_alias(self):
         ds = mock.MagicMock()
         var_url = 'http://test.crunch.io/api/datasets/123/variables/0001/'
         subvar1_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00001/'
@@ -195,6 +195,88 @@ class TestRecodes(TestCase):
 
         # make the actual response call
         combine_responses(ds, 'test', RESPONSE_MAP, 'name', 'alias')
+        call = ds.variables.create.call_args_list[0][0][0]
+
+        assert call == COMBINE_RESPONSES_PAYLOAD
+
+    def test_combine_responses_by_url(self):
+        ds = mock.MagicMock()
+        var_url = 'http://test.crunch.io/api/datasets/123/variables/0001/'
+        subvar1_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00001/'
+        subvar2_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00002/'
+        ds.entity.self = 'http://test.crunch.io/api/datasets/123/'
+
+        # mock subvariables
+        subvar_mock = mock.MagicMock()
+        subvar_mock.entity.self = subvar1_url
+        subvar2_mock = mock.MagicMock()
+        subvar2_mock.entity.self = subvar2_url
+
+        # mock parent variable
+        entity_mock = mock.MagicMock()
+        entity_mock.entity.self = var_url
+
+        # add dictionaries return to by functions
+        entity_mock.entity.subvariables.by.return_value = {
+            'sub1': subvar_mock,
+            'sub2': subvar2_mock
+        }
+
+        ds.variables.by.return_value = {
+            'test': entity_mock
+        }
+
+        # mock response from ds.session.get(variable_url)
+        var_response = mock.MagicMock()
+        var_response.payload = entity_mock.entity
+        ds.session.get.return_value = var_response
+
+        # make the actual response call
+        combine_responses(ds, var_url, RESPONSE_MAP, 'name', 'alias')
+        call = ds.variables.create.call_args_list[0][0][0]
+
+        assert call == COMBINE_RESPONSES_PAYLOAD
+
+    def test_combine_responses_by_entity(self):
+        ds = mock.MagicMock()
+        var_url = 'http://test.crunch.io/api/datasets/123/variables/0001/'
+        subvar1_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00001/'
+        subvar2_url = 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00002/'
+        ds.entity.self = 'http://test.crunch.io/api/datasets/123/'
+
+        # mock subvariables
+        subvar_mock = mock.MagicMock()
+        subvar_mock.entity.self = subvar1_url
+        subvar2_mock = mock.MagicMock()
+        subvar2_mock.entity.self = subvar2_url
+
+        # mock parent variable
+        entity_mock = mock.MagicMock()
+        entity_mock.entity.self = var_url
+
+        # add dictionaries return to by functions
+        entity_mock.entity.subvariables.by.return_value = {
+            'sub1': subvar_mock,
+            'sub2': subvar2_mock
+        }
+
+        ds.variables.by.return_value = {
+            'test': entity_mock
+        }
+
+        # mock response from ds.session.get(variable_url)
+        var_response = mock.MagicMock()
+        var_response.payload = entity_mock.entity
+        ds.session.get.return_value = var_response
+
+        entity = Entity(
+            mock.MagicMock(),
+            self=var_url,
+            body={}
+        )
+
+        # make the actual response call
+        combine_responses(ds, entity, RESPONSE_MAP, 'name', 'alias')
         call = ds.variables.create.call_args_list[0][0][0]
 
         assert call == COMBINE_RESPONSES_PAYLOAD

--- a/pycrunch/tests/test_recodes.py
+++ b/pycrunch/tests/test_recodes.py
@@ -56,6 +56,34 @@ RECODES_PAYLOAD = {
     }
 }
 
+COMBINE_RESPONSES_PAYLOAD = {
+    'element': 'shoji:entity',
+    'body': {
+        'alias': 'alias',
+        'description': '',
+        'name': 'name',
+        'expr': {
+            'function': 'combine_responses',
+            'args': [
+                {
+                    'variable': 'http://test.crunch.io/api/datasets/123/variables/0001/'
+                },
+                {
+                    'value': [
+                        {
+                            'name': 'newsubvar',
+                            'combined_ids': [
+                                'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00001/',
+                                'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00002/'
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+
 
 class TestRecodes(TestCase):
 
@@ -156,31 +184,5 @@ class TestRecodes(TestCase):
         # make the actual response call
         combine_responses(ds, 'test', RESPONSE_MAP, 'name', 'alias')
         call = ds.variables.create.call_args_list[0][0][0]
-        expected_payload = {
-            'element': 'shoji:entity',
-            'body': {
-                'alias': 'alias',
-                'description': '',
-                'name': 'name',
-                'expr': {
-                    'function': 'combine_responses',
-                    'args': [
-                        {
-                            'variable': 'http://test.crunch.io/api/datasets/123/variables/0001/'
-                        },
-                        {
-                            'value': [
-                                {
-                                    'name': 'newsubvar',
-                                    'combined_ids': [
-                                        'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00001/',
-                                        'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/00002/'
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        }
-        assert call == expected_payload
+
+        assert call == COMBINE_RESPONSES_PAYLOAD

--- a/pycrunch/tests/test_utilities.py
+++ b/pycrunch/tests/test_utilities.py
@@ -1,0 +1,38 @@
+from pycrunch.variables import validate_variable_url
+
+
+def test_variable_url_validation():
+    ds_url = 'https://test.crunch.io/api/datasets/b4d10b49c385aa405756fbbf572649d3/'
+    assert not validate_variable_url(ds_url)
+
+    var_url = (
+        'https://test.crunch.io/api/datasets/b4d10b49c385aa405756fbbf572649d3'
+        '/variables/b4d10b49c385aa405756fbbf572649d3/'
+    )
+    assert validate_variable_url(var_url)
+
+    var_wo_trailing_slash = (
+        'https://test.crunch.io/api/datasets/b4d10b49c385aa405756fbbf572649d3'
+        '/variables/b4d10b49c385aa405756fbbf572649d3'
+    )
+    assert validate_variable_url(var_wo_trailing_slash)
+
+    subvar_url = (
+        'https://test.crunch.io/api/datasets/b4d10b49c385aa405756fbbf572649d3'
+        '/variables/b4d10b49c385aa405756fbbf572649d3'
+        '/subvariables/b4d10b49c385aa405756fbbf572649d3/'
+    )
+    assert validate_variable_url(subvar_url)
+
+    subvar_wo_trailing_slash = (
+        'https://test.crunch.io/api/datasets/b4d10b49c385aa405756fbbf572649d3'
+        '/variables/b4d10b49c385aa405756fbbf572649d3'
+        '/subvariables/b4d10b49c385aa405756fbbf572649d3'
+    )
+    assert validate_variable_url(subvar_wo_trailing_slash)
+
+    var_catalog = (
+        'https://test.crunch.io/api/datasets/b4d10b49c385aa405756fbbf572649d3'
+        '/variables/b4d10b49c385aa405756fbbf572649d3/summary'
+    )
+    assert not validate_variable_url(var_catalog)

--- a/pycrunch/variables.py
+++ b/pycrunch/variables.py
@@ -1,4 +1,11 @@
+import re
+
 from pycrunch import elements
+
+VARIABLE_URL_REGEX = re.compile(
+    r"^(http|https):\/\/(.*)\/api\/datasets\/([\w\d]+)\/variables\/([\w\d]+)"
+    r"(\/subvariables\/([\w\d]*))?\/?$"
+)
 
 
 def cast(variable, type, format=None, offset=None, resolution=None):
@@ -16,3 +23,10 @@ def cast(variable, type, format=None, offset=None, resolution=None):
         payload['resolution'] = resolution
 
     return variable.cast.post(data=payload.json)
+
+
+def validate_variable_url(url):
+    """
+    Checks if a given url matches the variable url regex or not.
+    """
+    return VARIABLE_URL_REGEX.match(url)


### PR DESCRIPTION
Currently `combine_categories` and `combine_responses` receives the variable alias in the `from_alias` argument. These functions should be smart enough to accept any of the following:

* variable alias
* variable url
* variable object (`Entity` instance)

This PR adds the ability to accept any of the values above and replaces the `from_alias` argument name with `variable`.



