### PR TITLE
prevent name class with the `exclusion` attribute set for the exclusi…

### DIFF
--- a/docs/manipulation.md
+++ b/docs/manipulation.md
@@ -23,7 +23,7 @@ my_dataset = site.datasets.by('name').get('Omnibus').entity
 Now apply the exclusion filter:
 
 ```python
-my_dataset.exclusion("disposition != 0")
+my_dataset.exclude("disposition != 0")
 ```
 
 (Here, zero is the id (or code) assigned to completed interviews.)
@@ -31,7 +31,7 @@ my_dataset.exclusion("disposition != 0")
 We can also exclude a list of ids using:
 
 ```python
-my_dataset.exclusion("disposition in [0, 1]")
+my_dataset.exclude("disposition in [0, 1]")
 ```
 
 #### Filter expressions

--- a/pycrunch/datasets.py
+++ b/pycrunch/datasets.py
@@ -134,7 +134,7 @@ class Dataset(Entity):
             # Variable exists!, return the variable entity
             return variable.entity
 
-    def exclusion(self, expr=None):
+    def exclude(self, expr=None):
         """
         Given a dataset object, apply an exclusion filter to it (defined as an
         expression string).

--- a/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
+++ b/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
@@ -289,7 +289,7 @@ def main():
 
         # 1.1 Set a simple exclusion filter.
 
-        dataset.exclusion('identity > 5')
+        dataset.exclude('identity > 5')
         df = pandaslib.dataframe(dataset)
         assert len(df) == 5
         assert not any(r['identity'] > 5 for _, r in df.iterrows())
@@ -297,7 +297,7 @@ def main():
         # 1.2 More complex exclusion filters involving a categorical variable.
 
         expr = 'speak_spanish in [32766]'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -308,7 +308,7 @@ def main():
             assert row['identity'] in valid_ids
 
         expr = 'speak_spanish in (32766, 32767)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -320,7 +320,7 @@ def main():
             assert not isnan(row['speak_spanish'])
 
         expr = 'not (speak_spanish in (1, 2) and operating_system == "Linux")'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -337,7 +337,7 @@ def main():
         # 1.3 Exclusion filters with `has_any`.
 
         expr = 'hobbies.has_any([32766])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -349,7 +349,7 @@ def main():
             assert {'?': 32766} not in row['hobbies']
 
         expr = 'not hobbies.has_any([32766])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -361,7 +361,7 @@ def main():
             assert {'?': 32766} in row['hobbies']
 
         expr = 'hobbies.has_any([32766, 32767])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -375,7 +375,7 @@ def main():
                    {'?': 32767} not in row['hobbies']
 
         expr = 'music.has_any([32766])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -387,7 +387,7 @@ def main():
             assert {'?': 32766} not in row['music']
 
         expr = 'music.has_any([1])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -399,7 +399,7 @@ def main():
             assert 1 not in row['music']
 
         expr = 'music.has_any([1, 2])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -414,7 +414,7 @@ def main():
         # 1.4 Exclusion filters with `has_all`.
 
         expr = 'hobbies.has_all([32767])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -427,7 +427,7 @@ def main():
                                       {'?': 32767}, {'?': 32767}]
 
         expr = 'not hobbies.has_all([32767])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -440,7 +440,7 @@ def main():
                                       {'?': 32767}, {'?': 32767}]
 
         expr = 'music.has_all([1])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -452,7 +452,7 @@ def main():
             assert row['music'] != [1, 1, 1, 1, 1]
 
         expr = 'music.has_all([1]) or music.has_all([2])'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -466,7 +466,7 @@ def main():
                    row['music'] != [2, 2, 2, 2, 2]
 
         expr = 'not ( music.has_all([1]) or music.has_all([2]) )'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -482,7 +482,7 @@ def main():
         # 1.5 Exclusion filters with `duplicates`.
 
         expr = 'ip_address.duplicates()'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         seen_ip_addresses = []
         for _, row in df.iterrows():
@@ -492,7 +492,7 @@ def main():
         # 1.6 Exclusion filters with `valid` and `missing`.
 
         expr = 'valid(speak_spanish)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -504,7 +504,7 @@ def main():
             assert isnan(row['speak_spanish'])
 
         expr = 'not valid(speak_spanish)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -516,7 +516,7 @@ def main():
             assert not isnan(row['speak_spanish'])
 
         expr = 'missing(speak_spanish)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -528,7 +528,7 @@ def main():
             assert not isnan(row['speak_spanish'])
 
         expr = 'missing(hobbies)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -545,7 +545,7 @@ def main():
                                          {'?': 32767}, {'?': 32767}]
 
         expr = 'not missing(hobbies)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -562,7 +562,7 @@ def main():
                                          {'?': 32767}, {'?': 32767}]
 
         expr = 'valid(hobbies)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -575,7 +575,7 @@ def main():
                    {'?': 32767} in row['hobbies']
 
         expr = 'not valid(hobbies)'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -590,7 +590,7 @@ def main():
 
         # 1.7 Exclusion filter that refers to a subvariable by alias.
         expr = 'hobbies_1 == 4'
-        dataset.exclusion(expr)
+        dataset.exclude(expr)
         df = pandaslib.dataframe(dataset)
         valid_ids = [
             row[0] for row in ROWS
@@ -602,7 +602,7 @@ def main():
             assert row['hobbies'][0] != 4
 
         # 1.8 Clear the exclusion filter.
-        dataset.exclusion()
+        dataset.exclude()
         df = pandaslib.dataframe(dataset)
         assert len(df) == len(ROWS) - 1  # excluding the header
 

--- a/pycrunch/tests/test_datasets.py
+++ b/pycrunch/tests/test_datasets.py
@@ -60,12 +60,12 @@ class TestExclusionFilters(TestCase):
         ds.fragments.exclusion = '%sexclusion/' % self.ds_url
         ds.fragments.table = '%stable/' % self.ds_url
         ds.__class__ = Dataset
-        ds.exclusion = Dataset.exclusion
+        ds.exclude = Dataset.exclude
         ds.session.get.side_effect = _session_get
 
         # Action!
         exclusion_filter = 'disposition != 0'
-        ds.exclusion(ds, exclusion_filter)
+        ds.exclude(ds, exclusion_filter)
 
         # Ensure .patch was called the right way.
         assert len(ds.session.patch.call_args_list) == 1
@@ -92,8 +92,8 @@ class TestExclusionFilters(TestCase):
         ds = mock.MagicMock()
         ds.fragments.exclusion = '%sexclusion/' % self.ds_url
         ds.__class__ = Dataset
-        ds.exclusion = Dataset.exclusion
-        ds.exclusion(ds)
+        ds.exclude = Dataset.exclude
+        ds.exclude(ds)
 
         ds.session.patch.assert_called_once_with(
             ds.fragments.exclusion,


### PR DESCRIPTION
…on fragment in the dataset instance

while doing the sugared session I found that the `exclusion(...)` method of the `pycrunch.datasets.Dataset` class (that is used to create the exclusion filters) is conflicting with the attribute with the same name that is set by the parent class and is pointing to the exclusion fragment.

I renamed the method in the `Dataset` class to `.exclude(...)` as @nealrichardson suggested.

As I see it is working, I have updated the docs and tests pass (unit and integration), but I'll feel better if someone else can review before merging into master