### PR TITLE
make possible to connect using raw vs sugared sessions

### DIFF
--- a/pycrunch/__init__.py
+++ b/pycrunch/__init__.py
@@ -220,7 +220,7 @@ class CrunchTable(elements.Document):
 session = None
 
 
-def connect(user, pw, site_url="https://app.crunch.io/api/", progress_tracking=None):
+def connect(user, pw, site_url="https://app.crunch.io/api/", progress_tracking=None, sugar=False):
     """
     Log in to Crunch with a user/pw; return the top-level Site payload.  Using
     this or the other connect method (the first time only) stores a reference
@@ -229,13 +229,18 @@ def connect(user, pw, site_url="https://app.crunch.io/api/", progress_tracking=N
     Returns the API Root Entity, or errors if unable to connect.
     """
     global session
-    ret = Session(user, pw, progress_tracking=progress_tracking).get(site_url).payload
+    ret = Session(
+        email=user,
+        password=pw,
+        progress_tracking=progress_tracking,
+        sugar=sugar
+    ).get(site_url).payload
     if session is None:
         session = ret
     return ret
 
 
-def connect_with_token(token, site_url="https://us.crunch.io/api/", progress_tracking=None):
+def connect_with_token(token, site_url="https://us.crunch.io/api/", progress_tracking=None, sugar=False):
     """
     Log in to Crunch with a token; return the top-level Site payload. Using
     this or the other connect method (the first time only) stores a reference
@@ -247,7 +252,8 @@ def connect_with_token(token, site_url="https://us.crunch.io/api/", progress_tra
     ret = Session(
         token=token,
         domain=urllib.parse.urlparse(site_url).netloc,
-        progress_tracking=progress_tracking
+        progress_tracking=progress_tracking,
+        sugar=sugar
     ).get(site_url).payload
     if session is None:
         session = ret

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -97,7 +97,7 @@ def parse_element(session, j):
             j[k] = parse_element(session, v)
 
         elem = j.get("element", None)
-        if elem == 'shoji:entity' and is_dataset(j):
+        if session.has_sugar and elem == 'shoji:entity' and is_dataset(j):
             return pycrunch.datasets.Dataset(session, **j)
         if elem in elements:
             return elements[elem](session, **j)
@@ -248,12 +248,13 @@ class ElementSession(lemonpy.Session):
     handler_class = ElementResponseHandler
 
     def __init__(self, email=None, password=None, token=None, domain=None,
-                 progress_tracking=None):
+                 progress_tracking=None, sugar=False):
         self.email = email
         self.password = password
         self.token = token
         self.domain = domain
         self.progress_tracking = progress_tracking or DefaultProgressTracking()
+        self.has_sugar = sugar
         super(ElementSession, self).__init__()
 
 

--- a/pycrunch/shoji.py
+++ b/pycrunch/shoji.py
@@ -118,7 +118,9 @@ class Catalog(elements.Document):
         An entity is returned.
         """
         _cls = Entity
-        if 'self' in self and self['self'].endswith('/api/datasets/'):
+        if 'self' in self \
+                and self['self'].endswith('/api/datasets/')\
+                and self.session.has_sugar:
             # A Dataset is being created.
             _cls = pycrunch.datasets.Dataset
 

--- a/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
+++ b/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
@@ -270,7 +270,7 @@ def main():
     assert not invalid_credentials()
 
     # Login.
-    site = pycrunch.connect(CRUNCH_USER, CRUNCH_PASSWORD, CRUNCH_URL)
+    site = pycrunch.connect(CRUNCH_USER, CRUNCH_PASSWORD, CRUNCH_URL, sugar=True)
     assert isinstance(site, pycrunch.shoji.Catalog)
 
     # Create the test dataset.


### PR DESCRIPTION
By default, pycrunch connections should use raw shoji sessions, but when passing an additional parameter to the connect function we can instruct pycrunch to instantiate `element:dataset` responses as `pycrunch.datasets.Dataset` objects.

Currently I've added the `sugar=False` argument to `connect` and `connect_with_token`, and we can start a sugared session by passing `sugar=True` when connecting.

The other option that we discussed today is to create additional functions that explicitly starts a sugared connection (ie `connect_x` and `connect_with_token_x`), what do you think is better?

And finally, about the names, if you have better options please let me know, you know that I'm bad at naming stuff :)
