### PR TITLE
Registry of custom classes for every response entity

### DIFF
--- a/pycrunch/__init__.py
+++ b/pycrunch/__init__.py
@@ -178,7 +178,7 @@ You typically add new resources to a Catalog via its `create` method:
         ]
     })
 """
-
+from pycrunch.elements import EntityClassRegistry
 from six.moves import urllib
 
 from pycrunch import csvlib
@@ -274,3 +274,9 @@ def get_dataset(dataset_name_or_id, site=None):
         dataset = ds_catalog.by('id')[dataset_name_or_id].entity
     return dataset
 
+
+def register(entity_type, klass):
+    """
+    Register the python class for the entity type
+    """
+    EntityClassRegistry.register(entity_type, klass)

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -25,7 +25,6 @@ import json
 
 import six
 
-import pycrunch
 from pycrunch import lemonpy
 from pycrunch.progress import DefaultProgressTracking
 from .version import __version__
@@ -128,8 +127,11 @@ def parse_element(session, j):
             j[k] = parse_element(session, v)
 
         elem = j.get("element", None)
-        if elem == 'shoji:entity' and is_dataset(j):
-            return pycrunch.datasets.Dataset(session, **j)
+        if elem == 'shoji:entity':
+            obj = EntityClassRegistry.instantiate(session, j)
+            if obj is not None:
+                return obj
+
         if elem in elements:
             return elements[elem](session, **j)
         else:

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -33,6 +33,37 @@ from .version import __version__
 omitted = object()
 
 
+class EntityClassRegistry(object):
+    """Register custom classes for the different entity types"""
+
+    _registry = {}
+
+    @classmethod
+    def register(cls, entity_type, klass):
+        cls._registry[entity_type] = klass
+
+    @classmethod
+    def instantiate(cls, session, entity):
+        """
+        Instantiate the given entity using the registered class for the
+        entity type. Returns none if no class is available.
+        """
+        if 'specification' in entity:
+            klass = cls.class_for_specification(entity['specification'])
+            if klass is not None:
+                return klass(session, **entity)
+
+    @classmethod
+    def class_for_specification(cls, specification):
+        """
+        Return the class registered for a given specification. The entity
+        type name is the last element in the specification url.
+        """
+        parts = [p for p in specification.split('/') if p.strip() != '']
+        klass = cls._registry.get(parts[-1])
+        return klass
+
+
 class JSONObject(dict):
     """A base class for JSON objects."""
 

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -142,11 +142,6 @@ def parse_element(session, j):
         return j
 
 
-def is_dataset(j):
-    parts = j['self'].split('/')
-    return 'datasets' in parts and len(parts) == 7
-
-
 class Document(Element):
     """A base class for complete Documents classified by 'element'.
 

--- a/pycrunch/shoji.py
+++ b/pycrunch/shoji.py
@@ -7,6 +7,8 @@ for the latest Shoji specification.
 import json
 
 import time
+
+from pycrunch import EntityClassRegistry
 from six.moves import urllib
 
 import six
@@ -118,9 +120,9 @@ class Catalog(elements.Document):
         An entity is returned.
         """
         _cls = Entity
-        if 'self' in self and self['self'].endswith('/api/datasets/'):
-            # A Dataset is being created.
-            _cls = pycrunch.datasets.Dataset
+        if 'specification' in self:
+            _cls = EntityClassRegistry.class_for_specification(
+                self['specification']) or Entity
 
         if entity is None:
             entity = _cls(self.session)

--- a/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
+++ b/pycrunch/tests/integration/pycrunch_workflow_integration_test.py
@@ -269,6 +269,9 @@ def isnan(obj):
 def main():
     assert not invalid_credentials()
 
+    # Register the python class for datasets
+    pycrunch.register('datasets', pycrunch.datasets.Dataset)
+
     # Login.
     site = pycrunch.connect(CRUNCH_USER, CRUNCH_PASSWORD, CRUNCH_URL)
     assert isinstance(site, pycrunch.shoji.Catalog)


### PR DESCRIPTION
Instead of defining fixed classes for different entities as we currently do the dataset entities using the `pycrunch.datasets.Dataset` I propose the usage of a class registry that adds the ability to enable custom classes dynamically.

All we have to do is register a class to an entity type name (aka: specification name or resource name):

``` python
pycrunch.register('datasets', pycrunch.datasets.Dataset)
```

And this also works for other resources:

``` python
pycrunch.register('variables', my.custom.Variable)
```

The type of entity is extracted from the `specification` member in the response, so this should work with all specification names listed on https://beta.crunch.io/api/specifications/

The `pycrunch.shoji.Entity` is used by default when there are no custom classes registered for an entity type.

If this is accepted, then I'll have to write docs before merging.
