### PR TITLE
Expression prettifier

### DIFF
--- a/pycrunch/expressions.py
+++ b/pycrunch/expressions.py
@@ -528,6 +528,9 @@ def prettify(expr, ds=None):
             result = '%s.%s(%s)' % (
                 args[0], methods[f], ', '.join(str(x) for x in args[1:])
             )
+        else:
+            raise Exception('Unknown function "%s"' % f)
+
         if nest:
             result = '(%s)' % result
 

--- a/pycrunch/expressions.py
+++ b/pycrunch/expressions.py
@@ -43,6 +43,8 @@ ready for the crunch API.
 import ast
 import copy
 
+import pycrunch
+from pycrunch.variables import validate_variable_url
 CRUNCH_FUNC_MAP = {
     'valid': 'is_valid',
     'missing': 'is_missing',

--- a/pycrunch/expressions.py
+++ b/pycrunch/expressions.py
@@ -78,7 +78,7 @@ COMPARISSON_OPERATORS = [
     '<',
     '>',
     '<=',
-    '=>',
+    '>=',
     '~=',
     'in',
     'and',

--- a/pycrunch/expressions.py
+++ b/pycrunch/expressions.py
@@ -519,8 +519,11 @@ def prettify(expr, ds=None):
     def _transform(f, args, nest=False):
         result = ''
         if f in operators:
-            op = ' %s ' % f
-            result = op.join(str(x) for x in args)
+            if len(args) == 1:
+                result = '%s %s' % (f, args[0])
+            else:
+                op = ' %s ' % f
+                result = op.join(str(x) for x in args)
         elif f in methods:
             result = '%s.%s(%s)' % (
                 args[0], methods[f], ', '.join(str(x) for x in args[1:])

--- a/pycrunch/expressions.py
+++ b/pycrunch/expressions.py
@@ -570,7 +570,7 @@ def prettify(expr, ds=None):
         has_child_and_or = 'or' in child_functions
         nest = parent is not None and (
             has_child_and_or
-            or (parent == 'or' and len(child_functions)>1)
+            or (parent == 'or' and len(child_functions) > 1)
             or _func == 'or'
         )
         return _transform(_func, args, nest=nest)

--- a/pycrunch/tests/test_expressions.py
+++ b/pycrunch/tests/test_expressions.py
@@ -2096,6 +2096,7 @@ class TestExpressionProcessing(TestCase):
                 }
             ]
         }
+
 class TestExpressionPrettify(TestCase):
 
     def test_simple_eq(self):
@@ -2112,5 +2113,38 @@ class TestExpressionPrettify(TestCase):
         }
 
         expected = 'age == 1'
+        cel = prettify(expr)
+        assert expected == cel
+
+    def test_and(self):
+        expr = {
+            'function': 'and',
+            'args': [
+                {
+                    'function': '>',
+                    'args': [
+                        {
+                            'variable': 'age'
+                        },
+                        {
+                            'value': 1
+                        }
+                    ]
+                },
+                {
+                    'function': '==',
+                    'args': [
+                        {
+                            'variable': 'favcolor'
+                        },
+                        {
+                            'value': 2
+                        }
+                    ]
+                }
+            ]
+        }
+
+        expected = 'age > 1 and favcolor == 2'
         cel = prettify(expr)
         assert expected == cel

--- a/pycrunch/tests/test_expressions.py
+++ b/pycrunch/tests/test_expressions.py
@@ -2148,3 +2148,54 @@ class TestExpressionPrettify(TestCase):
         expected = 'age > 1 and favcolor == 2'
         cel = prettify(expr)
         assert expected == cel
+
+    def test_nested_or(self):
+        expr = {
+            'function': 'and',
+            'args': [
+                {
+                    'function': '>',
+                    'args': [
+                        {
+                            'variable': 'age'
+                        },
+                        {
+                            'value': 1
+                        }
+                    ]
+                },
+                {
+                    'function': 'or',
+                    'args': [
+
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'favcolor'
+                                },
+                                {
+                                    'value': 2
+                                }
+                            ]
+                        },
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'genre'
+                                },
+                                {
+                                    'value': 1
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        expected = 'age > 1 and (favcolor == 2 or genre == 1)'
+        cel = prettify(expr)
+        assert expected == cel
+

--- a/pycrunch/tests/test_expressions.py
+++ b/pycrunch/tests/test_expressions.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from pycrunch.datasets import parse_expr
 from pycrunch.datasets import process_expr
+from pycrunch.expressions import prettify
 
 
 class TestExpressionParsing(TestCase):
@@ -2095,3 +2096,21 @@ class TestExpressionProcessing(TestCase):
                 }
             ]
         }
+class TestExpressionPrettify(TestCase):
+
+    def test_simple_eq(self):
+        expr = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': 'age'
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+
+        expected = 'age == 1'
+        cel = prettify(expr)
+        assert expected == cel

--- a/pycrunch/tests/test_expressions.py
+++ b/pycrunch/tests/test_expressions.py
@@ -1245,6 +1245,63 @@ class TestExpressionParsing(TestCase):
             ]
         }
 
+    def test_parse_not_a_in_b(self):
+        expr = "a not in [1, 2, 3]"
+        expr_obj = parse_expr(expr)
+        assert expr_obj == {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'in',
+                    'args': [
+                        {
+                            'variable': 'a'
+                        },
+                        {
+                            'value': [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        expr = "not a in [1, 2, 3]"
+        expr_obj = parse_expr(expr)
+        assert expr_obj == {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'in',
+                    'args': [
+                        {
+                            'variable': 'a'
+                        },
+                        {
+                            'value': [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        expr = "not (a in [1, 2, 3])"
+        expr_obj = parse_expr(expr)
+        assert expr_obj == {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'in',
+                    'args': [
+                        {
+                            'variable': 'a'
+                        },
+                        {
+                            'value': [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        }
 
 # 'diposition code 0 (incompletes)':
 # intersection(

--- a/pycrunch/tests/test_expressions.py
+++ b/pycrunch/tests/test_expressions.py
@@ -1,3 +1,5 @@
+import json
+
 import pycrunch
 import pytest
 from unittest import mock
@@ -2311,3 +2313,677 @@ class TestExpressionPrettify(TestCase):
             'Valid dataset instance is required to resolve variable urls '
             'in the expression'
         )
+
+    def test_parse_equal_string(self):
+        expr_obj = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': 'name'
+                },
+                {
+                    'value': 'John Doe'
+                }
+            ]
+        }
+        cel = prettify(expr_obj)
+        assert cel == "name == 'John Doe'"
+
+        # Reversed.
+        expr_obj = {
+            'function': '==',
+            'args': [
+                {
+                    'value': 'John Doe'
+                },
+                {
+                    'variable': 'address'
+                }
+            ]
+        }
+        cel = prettify(expr_obj)
+        assert cel == "'John Doe' == address"
+
+    def test_parse_equal_string_escape_quote(self):
+        expr_obj = {
+            'function': '==',
+            'args': [
+                {
+                    'value': '''John's Name'''
+                },
+                {
+                    'variable': 'address'
+                }
+            ]
+        }
+        cel = prettify(expr_obj)
+        # Actually is a single backslash escaping the quote,
+        # but we need to escape the actual backslash and quote
+        # for this comparisson
+        assert cel == "'John\\\'s Name' == address"
+
+    def test_parse_notequal_int(self):
+        expr = {
+            'function': '!=',
+            'args': [
+                {
+                    'variable': 'age'
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "age != 1"
+
+        # Reversed.
+        expr = {
+            'function': '!=',
+            'args': [
+                {
+                    'value': 1
+                },
+                {
+                    'variable': 'age'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "1 != age"
+
+    def test_parse_notequal_string(self):
+        expr = {
+            'function': '!=',
+            'args': [
+                {
+                    'variable': 'name'
+                },
+                {
+                    'value': 'John Doe'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "name != 'John Doe'"
+
+        # Reversed.
+        expr = {
+            'function': '!=',
+            'args': [
+                {
+                    'value': 'John Doe'
+                },
+                {
+                    'variable': 'name'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "'John Doe' != name"
+
+    def test_parse_less_than(self):
+        expr = {
+            'function': '<',
+            'args': [
+                {
+                    'variable': 'caseid'
+                },
+                {
+                    'value': 1234
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "caseid < 1234"
+
+        # Reversed.
+        expr = {
+            'function': '<',
+            'args': [
+                {
+                    'value': 1234
+                },
+                {
+                    'variable': 'caseid'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "1234 < caseid"
+
+    def test_parse_less_than_equal(self):
+        expr = {
+            'function': '<=',
+            'args': [
+                {
+                    'variable': 'caseid'
+                },
+                {
+                    'value': 1234
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "caseid <= 1234"
+
+        # Reversed.
+        expr = {
+            'function': '<=',
+            'args': [
+                {
+                    'value': 1234
+                },
+                {
+                    'variable': 'caseid'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "1234 <= caseid"
+
+    def test_parse_greater_than(self):
+        expr = {
+            'function': '>',
+            'args': [
+                {
+                    'variable': 'caseid'
+                },
+                {
+                    'value': 1234
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "caseid > 1234"
+
+        # Reversed.
+        expr = {
+            'function': '>',
+            'args': [
+                {
+                    'value': 1234
+                },
+                {
+                    'variable': 'caseid'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "1234 > caseid"
+
+    def test_parse_greater_than_equal(self):
+        expr = {
+            'function': '>=',
+            'args': [
+                {
+                    'variable': 'caseid'
+                },
+                {
+                    'value': 1234
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "caseid >= 1234"
+
+        # Reversed.
+        expr = {
+            'function': '>=',
+            'args': [
+                {
+                    'value': 1234
+                },
+                {
+                    'variable': 'caseid'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "1234 >= caseid"
+
+    def test_parse_compare_variable_against_another_variable(self):
+        expr = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': 'starttdate'
+                },
+                {
+                    'variable': 'arrivedate'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "starttdate == arrivedate"
+
+        expr = {
+            'function': '!=',
+            'args': [
+                {
+                    'variable': 'starttdate'
+                },
+                {
+                    'variable': 'arrivedate'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "starttdate != arrivedate"
+
+        expr = {
+            'function': '<',
+            'args': [
+                {
+                    'variable': 'starttdate'
+                },
+                {
+                    'variable': 'arrivedate'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "starttdate < arrivedate"
+
+        expr = {
+            'function': '<=',
+            'args': [
+                {
+                    'variable': 'starttdate'
+                },
+                {
+                    'variable': 'arrivedate'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "starttdate <= arrivedate"
+
+        expr = {
+            'function': '>',
+            'args': [
+                {
+                    'variable': 'starttdate'
+                },
+                {
+                    'variable': 'arrivedate'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "starttdate > arrivedate"
+
+        expr = {
+            'function': '>=',
+            'args': [
+                {
+                    'variable': 'starttdate'
+                },
+                {
+                    'variable': 'arrivedate'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "starttdate >= arrivedate"
+
+    def test_parse_multiple_boolean_conditions(self):
+        expr = {
+            'function': 'or',
+            'args': [
+                {
+                    'function': 'and',
+                    'args': [
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'identity'
+                                },
+                                {
+                                    'value': 1
+                                }
+                            ]
+                        },
+                        {
+                            'function': '<=',
+                            'args': [
+                                {
+                                    'variable': 'caseid'
+                                },
+                                {
+                                    'variable': 'surveyid'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    'function': '>=',
+                    'args': [
+                        {
+                            'variable': 'identity'
+                        },
+                        {
+                            'value': 2
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel =='(identity == 1 and caseid <= surveyid) or identity >= 2'
+
+    def test_parse_value_in_list(self):
+        expr = {
+            'function': 'in',
+            'args': [
+                {
+                    'variable': 'web_browser'
+                },
+                {
+                    'value': ['abc', 'dfg', 'hij']
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "web_browser in ['abc', 'dfg', 'hij']"
+
+    def test_parse_value_not_in_list(self):
+        expr = {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'in',
+                    'args': [
+                        {
+                            'variable': 'country'
+                        },
+                        {
+                            'value': [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+
+        # TODO: look for improvements:
+        #   despite it is valid, seems better to have
+        #   `x not in y` than `not x in y`
+        # assert cel == 'country not in [1, 2, 3]'
+        assert cel == 'not country in [1, 2, 3]'
+
+    def test_parse_omnibus_rule_1(self):
+
+        expr = {
+            'function': 'and',
+            'args': [
+                {
+                    'function': '==',
+                    'args': [
+                        {
+                            'variable': 'disposition'
+                        },
+                        {
+                            'value': 0
+                        }
+                    ]
+                },
+                {
+                    'function': '==',
+                    'args': [
+                        {
+                            'variable': 'exit_status'
+                        },
+                        {
+                            'value': 0
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "disposition == 0 and exit_status == 0"
+
+    def test_parse_has_any(self):
+        expr = {
+            'function': 'any',
+            'args': [
+                {
+                    'variable': 'Q2'
+                },
+                {
+                    'value': [1, 2, 3]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel =='Q2.has_any([1, 2, 3])'
+
+    def test_parse_has_all(self):
+        expr = {
+            'function': 'all',
+            'args': [
+                {
+                    'variable': 'Q2'
+                },
+                {
+                    'value': [1, 2, 3]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel =='Q2.has_all([1, 2, 3])'
+
+    def test_parse_has_count(self):
+        expr = {
+            'function': 'has_count',
+            'args': [
+                {
+                    'variable': 'Q2'
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel =='Q2.has_count(1)'
+
+    def test_parse_omnibus_rule_2_complex(self):
+        expr = {
+            'function': 'or',
+            'args': [{
+                    'function': 'and',
+                    'args': [
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'disposition'
+                                },
+                                {
+                                    'value': 0
+                                }
+                            ]
+                        },
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'exit_status'
+                                },
+                                {
+                                    'value': 1
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    'function': 'and',
+                    'args': [
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'disposition'
+                                },
+                                {
+                                    'value': 0
+                                }
+                            ]
+                        },
+                        {
+                            'function': '==',
+                            'args': [
+                                {
+                                    'variable': 'exit_status'
+                                },
+                                {
+                                    'value': 0
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]}
+        cel = prettify(expr)
+        assert cel == "(disposition == 0 and exit_status == 1) or " \
+               "(disposition == 0 and exit_status == 0)"
+
+    def test_parse_omnibus_has_any(self):
+        expr = {
+            'function': 'any',
+            'args': [
+                {
+                    'variable': 'CompanyTurnover'
+                },
+                {
+                    'value': [99]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "CompanyTurnover.has_any([99])"
+
+        expr = {
+            'function': 'any',
+            'args': [
+                {
+                    'variable': 'sector'
+                },
+                {
+                    'value': [2, 3, 98, 99]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "sector.has_any([2, 3, 98, 99])"
+
+    def test_parse_negated_expr(self):
+        expr = {
+            'function': 'not',
+            'args': [
+                {
+                    'function': '==',
+                    'args': [
+                        {
+                            'variable': 'age'
+                        },
+                        {
+                            'value': 1
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "not age == 1"
+
+    def test_parse_negated_method_call(self):
+        expr = {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'any',
+                    'args': [
+                        {
+                            'variable': 'Q2'
+                        },
+                        {
+                            'value': [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel =='not Q2.has_any([1, 2, 3])'
+
+        expr = {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'all',
+                    'args': [
+                        {
+                            'variable': 'Q2'
+                        },
+                        {
+                            'value': [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel =='not Q2.has_all([1, 2, 3])'
+
+    def test_parse_duplicates_method(self):
+        expr = {
+            'function': 'duplicates',
+            'args': [
+                {
+                    'variable': 'identity'
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "identity.duplicates()"
+
+        # Negated.
+        expr = {
+            'function': 'not',
+            'args': [
+                {
+                    'function': 'duplicates',
+                    'args': [
+                        {
+                            'variable': 'identity'
+                        }
+                    ]
+                }
+            ]
+        }
+        cel = prettify(expr)
+        assert cel == "not identity.duplicates()"
+
+    def test_unknown_function(self):
+        expr = {
+            'function': '>>',  # Assuming this is a typo
+            'args': [
+                {
+                    'variable': 'identity'
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+        with pytest.raises(Exception) as err:
+            prettify(expr)
+
+        assert str(err.value) == 'Unknown function ">>"'
+

--- a/pycrunch/tests/test_expressions.py
+++ b/pycrunch/tests/test_expressions.py
@@ -2199,3 +2199,68 @@ class TestExpressionPrettify(TestCase):
         cel = prettify(expr)
         assert expected == cel
 
+    def test_complex(self):
+        expr = {
+            'function': 'and',
+            'args': [
+                {
+                    'function': '>',
+                    'args': [
+                        {
+                            'variable': 'age'
+                        },
+                        {
+                            'value': 55
+                        }
+                    ]
+                },
+                {
+                    'function': 'or',
+                    'args': [
+                        {
+                            'function': 'and',
+                            'args': [
+                                {
+                                    'function': '==',
+                                    'args': [
+                                        {
+                                            'variable': 'genre'
+                                        },
+                                        {
+                                            'value': 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    'function': '==',
+                                    'args': [
+                                        {
+                                            'variable': 'favfruit'
+                                        },
+                                        {
+                                            'value': 9
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            'function': 'in',
+                            'args': [
+                                {
+                                    'variable': 'favcolor'
+                                },
+                                {
+                                    'value': [3, 4, 5]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        expected = 'age > 55 and ((genre == 1 and favfruit == 9) or favcolor in [3, 4, 5])'
+        cel = prettify(expr)
+        assert expected == cel
+


### PR DESCRIPTION
Translate the crunch expression dictionary to the string representation (CEL: Crunch Expression Language)

Transforms: 

```
{
    'function': '==',
    'args': [
        {
            'variable': 'age'
        },
        {
            'value': 1
        }
    ]
}
```

into: `age == 1`

See commits for basic tests.

Still needs work in order to add support of all crunch functions and methods.